### PR TITLE
ci: change auto-merge runner to ubuntu 24

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   merge-to-branches:
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/create-github-app-token@v1


### PR DESCRIPTION
# Overview
- Changed auto-merge runner image to ubuntu 24.04
- This solves the [issue](https://github.com/algorandfoundation/xgov-beta-sc/actions/runs/12352003454/job/34468108134#step:3:31) with installing yq 
- ubuntu 24.04 is in the process of being rolled out as `latest`, we should switch to `ubuntu-24.04` after the rollout is complete #86