### PR TITLE
chore: deploy with extra pages

### DIFF
--- a/smart_contracts/xgov_registry/deploy_config.py
+++ b/smart_contracts/xgov_registry/deploy_config.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 def deploy(
     algod_client: AlgodClient,
     indexer_client: IndexerClient,
+    app_spec: algokit_utils.ApplicationSpecification,
     deployer: algokit_utils.Account,
 ) -> None:
     from smart_contracts.artifacts.xgov_registry.x_gov_registry_client import (


### PR DESCRIPTION
This PR is a patch to solve an AlgoKit deployment issue.

Currently, the AlgoKit deployment configuration has a [known issue](https://github.com/algorandfoundation/algokit-utils-py/issues/66) and does not catch App extra-pages changes as breaking changes (as it does for App state schema breaking changes). Therefore, the AlgoKit deployment fails silently when updating an App whose program size exceeds the one set on creation.

The deployment will now allocate the maximum extra pages by default, and the Update App behavior will be restored after the first deployment succeeds.