### PR TITLE
ci: remove id-token permission from CI workflow

### DIFF
--- a/.github/workflows/xgov-beta-sc-ci.yml
+++ b/.github/workflows/xgov-beta-sc-ci.yml
@@ -10,9 +10,6 @@ on:
     # * is a special character in YAML so you have to quote this string
     - cron: "0 0 1 * *" # Run once a month at midnight on the 1st of the month
 
-permissions:
-  id-token: write
-
 jobs:
   validate-xgov-beta-sc:
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
# Overview
- Removed id-token write permission from CI workflow.