### PR TITLE
Updated docs-cd.yaml workflow file to pass the correct permissions

### DIFF
--- a/.github/workflows/docs-cd.yaml
+++ b/.github/workflows/docs-cd.yaml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: ["Mainnet Stable Release xgov-beta-sc"]
     types: [completed]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Updated `docs-cd.yaml` workflow file to pass the correct permissions to the `docs-ci.yaml` workflow.