### PR TITLE
Revert "bump(ver): v3.0.0"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xgov-beta-sc"
-version = "3.0.0"
+version = "2.0.0"
 description = "Algorand xGov Beta Smart Contracts"
 authors = ["Algorand Foundation <contact@algorand.foundation>"]
 packages = [{ include = "smart_contracts" }]


### PR DESCRIPTION
Reverts algorandfoundation/xgov-beta-sc#381 from main. We need to sync `release` first to trigger the release properly.